### PR TITLE
Update to Rust 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ description = "Parser and writer for the PLS playlist format"
 documentation = "https://rawcdn.githack.com/nabijaczleweli/pls-rs/doc/pls/index.html"
 repository = "https://github.com/nabijaczleweli/pls-rs"
 readme = "README.md"
+edition = "2024"
 keywords = ["music", "playlist", "pls", "parse"]
 categories = ["parser-implementations"]
 license = "MIT"

--- a/tests/parse/incorrect.rs
+++ b/tests/parse/incorrect.rs
@@ -6,7 +6,7 @@ use ini::ini::Error as IniError;
 fn invalid_version() {
     assert_eq!(parse(&mut &b"[playlist]\n\
                              Version=-1\n"[..]),
-               Err(ParseError::InvalidInteger(u64::from_str_radix("-1", 10).unwrap_err())));
+               Err(ParseError::InvalidInteger("-1".parse::<u64>().unwrap_err())));
     assert_eq!(parse(&mut &b"[playlist]\n\
                              Version=0\n"[..]),
                Err(ParseError::InvalidVersion(0)));
@@ -49,7 +49,7 @@ fn missing_file_entry() {
 fn invalid_number_of_entries() {
     assert_eq!(parse(&mut &b"[playlist]\n\
                              NumberOfEntries=-1"[..]),
-               Err(ParseError::InvalidInteger(u64::from_str_radix("-1", 10).unwrap_err())));
+               Err(ParseError::InvalidInteger("-1".parse::<u64>().unwrap_err())));
 }
 
 #[test]
@@ -59,7 +59,7 @@ fn invalid_length() {
                              Length1=Abolish the Burgeoisie!\n\
                              NumberOfEntries=1"
                                [..]),
-               Err(ParseError::InvalidInteger(u64::from_str_radix("Abolish the Burgeoisie!", 10).unwrap_err())));
+               Err(ParseError::InvalidInteger("Abolish the Burgeoisie!".parse::<u64>().unwrap_err())));
 }
 
 #[test]


### PR DESCRIPTION
Bumps the Rust edition to 2024 and resolves all warnings/errors. No functional changes.

I see this hasn't been updated in a while, so no worries if you'd rather not maintain this anymore. Just thought I'd see if there's interest still.